### PR TITLE
add weekly budget

### DIFF
--- a/ExpenseTracker/Budget/BudgetComponent.swift
+++ b/ExpenseTracker/Budget/BudgetComponent.swift
@@ -1,0 +1,37 @@
+//
+//  BudgetComponent.swift
+//  ExpenseTracker
+//
+//  Created by Cole Whaley on 2/17/25.
+//
+
+import SwiftUI
+
+struct BudgetComponent: View {
+    
+    @Binding var budget: String
+    
+    var body: some View {
+        HStack{
+            Text("Weekly Budget")
+            Image(systemName: "arrow.right")
+                .foregroundColor(.orange)
+            
+            HStack {
+                Text("$")
+                TextField("", text: $budget)
+                    .multilineTextAlignment(.center)
+                    .padding(.trailing, 12)
+            }
+            .keyboardType(.decimalPad)
+            .foregroundColor(.orange)
+            .padding(8)
+            .frame(width: 130)
+            .background(Color(.orange.opacity(0.1)))
+            .clipShape(RoundedRectangle(cornerRadius: 15))
+            
+        }
+        .fontWeight(.semibold)
+        .font(.title2)
+    }
+}

--- a/ExpenseTracker/ContentView.swift
+++ b/ExpenseTracker/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \DayExpenses.day) private var dayExpensesFetch: [DayExpenses]
     @State private var weekExpenses: [DayExpenses] = []
+    @State var budget: String = "0"
     
     var weeklyCost: Double {
         let dailyTotals = weekExpenses.map { dayExpenseList in
@@ -34,7 +35,9 @@ struct ContentView: View {
                     .padding(20)
                     .foregroundColor(.green)
                 
-                ExpenseBreakdown(weekExpenses: $weekExpenses)
+                BudgetComponent(budget: $budget)
+                
+                ExpenseBreakdown(weekExpenses: $weekExpenses, budget: $budget)
                 
                 HStack{
                     Text("Week Total")

--- a/ExpenseTracker/DayExpenses/DayExpensesComponent.swift
+++ b/ExpenseTracker/DayExpenses/DayExpensesComponent.swift
@@ -68,6 +68,7 @@ struct DayExpensesComponent: View {
                                 .background(Color.white)
                                 .clipShape(RoundedRectangle(cornerRadius: 10))
                             TextField("$", text: $expenseCost)
+                                .keyboardType(.decimalPad)
                                 .padding()
                                 .frame(maxWidth: 100, alignment: .leading)
                                 .multilineTextAlignment(.leading)

--- a/ExpenseTracker/WeekExpenses/ExpenseBreakdown.swift
+++ b/ExpenseTracker/WeekExpenses/ExpenseBreakdown.swift
@@ -10,6 +10,7 @@ import Charts
 
 struct ExpenseBreakdown: View {
     @Binding var weekExpenses: [DayExpenses]
+    @Binding var budget: String
     
     private let dayLabel: [String] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
     
@@ -21,22 +22,41 @@ struct ExpenseBreakdown: View {
     }
     
     var maxTotalDay: DayExpenseTotal? {
-        dailyTotals.max{ $0.total < $1.total }
+        dailyTotals.max { $0.total < $1.total }
+    }
+    
+    var budgetValue: Double {
+        Double(budget) ?? 0
     }
     
     var body: some View {
-        Chart(dailyTotals){ data in
-            LineMark(
-                x: .value("Day", dayLabel[data.day]),
-                y: .value("Total", data.total)
-            )
-            .foregroundStyle(.green)
-            .interpolationMethod(.monotone)
+        Chart {
+
+            ForEach(dailyTotals, id: \.day) { data in
+                LineMark(
+                    x: .value("Day", dayLabel[data.day]),
+                    y: .value("Total", data.total)
+                )
+                .foregroundStyle(.green)
+                .interpolationMethod(.monotone)
+            }
+            if budgetValue > 0 {
+                RuleMark(y: .value("Budget", budgetValue / 7))
+                    .foregroundStyle(.orange)
+                    .lineStyle(StrokeStyle(lineWidth: 2, dash: [5])) // Dotted line
+                    .annotation(position: .top, alignment: .leading) {
+                        Text("$\(Int(budgetValue / 7)) / day")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                            .bold()
+                }
+                    .zIndex(-10)
+            }
+            
         }
         .padding(20)
         .chartXScale(domain: dayLabel)
-        .chartYScale(domain: 0...((maxTotalDay?.total ?? 0) + 300))
+        .chartYScale(domain: 0...max((maxTotalDay?.total ?? 0) + 300, budgetValue + 50))
         .frame(minHeight: 150)
     }
-    
 }


### PR DESCRIPTION
Input to add weekly budget.

Applies line (divided by 7) of weekly budget on graph to show user when they go over/under budget.